### PR TITLE
[fix] Support the base_url config on the webserver

### DIFF
--- a/src/core/api/index.ts
+++ b/src/core/api/index.ts
@@ -9,6 +9,7 @@ import {
 } from 'utils/fetch';
 import { Action } from 'utils/hooks/actions';
 import { AuthContainter } from 'core/auth/container';
+import { uriParser } from 'utils';
 
 interface State<T> {
   loading: boolean;
@@ -60,13 +61,18 @@ export const useFlexgetAPI = <Res>(url: string) => {
     loading: false,
   });
   const cancelled = useRef(false);
+  const baseURI = useRef(uriParser(document.baseURI));
 
   const requestFn = useCallback(
     <Req = undefined>(method: Method, body: Req) => {
       const fn = async () => {
         dispatch({ type: Constants.START });
 
-        const payload = await request<Res, Req>(`/api${url}`, method, body);
+        const payload = await request<Res, Req>(
+          `${baseURI.current.pathname}api${url}`,
+          method,
+          body,
+        );
 
         if (cancelled.current) {
           return undefined;

--- a/src/core/history/index.js
+++ b/src/core/history/index.js
@@ -1,5 +1,0 @@
-import { createBrowserHistory } from 'history';
-
-export default createBrowserHistory({
-  basename: process.env.NODE_ENV === 'production' ? '/v2/' : '',
-});

--- a/src/core/history/index.ts
+++ b/src/core/history/index.ts
@@ -1,0 +1,8 @@
+import { createBrowserHistory } from 'history';
+import { uriParser } from 'utils';
+
+export default createBrowserHistory({
+  basename: `${uriParser(document.baseURI).pathname}${
+    process.env.NODE_ENV === 'production' ? 'v2/' : ''
+  }`,
+});

--- a/src/utils/fetch.ts
+++ b/src/utils/fetch.ts
@@ -1,4 +1,5 @@
 import * as humps from 'humps';
+import { uriParser } from 'utils';
 
 export class StatusError extends Error {
   status?: number;
@@ -99,7 +100,11 @@ const requestOld = async <PayloadType, BodyType = undefined>(
   method: Method,
   rawBody?: BodyType,
 ): Promise<APIResponse<PayloadType>> => {
-  const response = await request<PayloadType, typeof rawBody>(`/api${resource}`, method, rawBody);
+  const response = await request<PayloadType, typeof rawBody>(
+    `${uriParser(document.baseURI).pathname}api${resource}`,
+    method,
+    rawBody,
+  );
   if ('error' in response) {
     throw response.error;
   }

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,0 +1,5 @@
+export const uriParser = (uri: string) => {
+  const a = document.createElement('a');
+  a.href = uri;
+  return a;
+};

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -5,17 +5,13 @@ const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 const { BundleAnalyzerPlugin } = require('webpack-bundle-analyzer');
 const webpack = require('webpack');
 
-const __DEBUG__ = !!process.env.DEBUG; const __DEV__ = process.env.NODE_ENV !== 'production';
+const __DEBUG__ = !!process.env.DEBUG;
+const __DEV__ = process.env.NODE_ENV !== 'production';
 const mode = __DEV__ ? 'development' : 'production';
+const PATH_PREFIX = 'v2';
 
 const entry = {
-  main: [
-    ...(__DEV__ ? [
-      'react-hot-loader/patch',
-    ] : []),
-    'whatwg-fetch',
-    './src/app.tsx',
-  ],
+  main: [...(__DEV__ ? ['react-hot-loader/patch'] : []), 'whatwg-fetch', './src/app.tsx'],
   vendor: [
     'redux',
     'react-redux',
@@ -30,7 +26,7 @@ const entry = {
 const output = {
   path: __DEV__ ? __dirname : path.join(__dirname, 'dist', 'assets'),
   filename: __DEV__ ? '[name].bundle.js' : '[name].[chunkhash].js',
-  publicPath: __DEV__ ? '/' : '/v2/assets/',
+  publicPath: __DEV__ ? '/' : `${PATH_PREFIX}/assets/`,
 };
 
 const htmlConfig = {
@@ -42,7 +38,7 @@ if (__DEV__) {
   htmlConfig.base = '/';
 } else {
   htmlConfig.filename = '../index.html';
-  htmlConfig.base = '/v2/';
+  htmlConfig.base = `{{ base_url }}/`;
 }
 
 const plugins = [
@@ -51,15 +47,21 @@ const plugins = [
     tsconfig: path.resolve('tsconfig.json'),
   }),
   new HtmlWebpackPlugin(htmlConfig),
-  ...(__DEV__ ? [new webpack.HotModuleReplacementPlugin()] : [
-    new MiniCssExtractPlugin({
-      filename: '[name].[chunkhash].css',
-      allChunks: true,
-    }),
-  ]),
-  ...(__DEBUG__ ? [new BundleAnalyzerPlugin({
-    analyzerMode: 'server',
-  })] : []),
+  ...(__DEV__
+    ? [new webpack.HotModuleReplacementPlugin()]
+    : [
+        new MiniCssExtractPlugin({
+          filename: '[name].[chunkhash].css',
+          allChunks: true,
+        }),
+      ]),
+  ...(__DEBUG__
+    ? [
+        new BundleAnalyzerPlugin({
+          analyzerMode: 'server',
+        }),
+      ]
+    : []),
 ];
 
 const config = {
@@ -70,10 +72,7 @@ const config = {
   devtool: __DEV__ ? 'eval-source-map' : 'source-map',
   resolve: {
     extensions: ['.js', '.jsx', '.ts', '.tsx'],
-    modules: [
-      path.resolve('./src'),
-      'node_modules',
-    ],
+    modules: [path.resolve('./src'), 'node_modules'],
     alias: {
       'react-dom': '@hot-loader/react-dom',
     },
@@ -108,7 +107,19 @@ const config = {
       },
       {
         test: /\.css$/,
-        use: [...(__DEV__ ? ['style-loader'] : [MiniCssExtractPlugin.loader]), 'css-loader'],
+        use: [
+          ...(__DEV__
+            ? ['style-loader']
+            : [
+                {
+                  loader: MiniCssExtractPlugin.loader,
+                  options: {
+                    publicPath: '',
+                  },
+                },
+              ]),
+          'css-loader',
+        ],
       },
     ],
   },


### PR DESCRIPTION
### Motivation for changes:
Fixes the base url issues. 

### Detailed changes:
- generate a jinja template instead of raw html to fill in the base url
- fix the router and the fetch client to use `document.baseURI`
- fix the public path for css files

### Addressed issues:
- Fixes #24

### Implemented feature requests:
- Feathub #[XX](https://feathub.com/Flexget/Flexget/+XX).

#### To Do:

- [x] wait until Flexget/Flexget#2518 is merged

