### PR TITLE
Add Empty Commit to Main Repo on webui release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,11 +3,10 @@ name: Continuous Integration
 on:
   push:
     branches:
-      - '**'
-      - '!master'
+      - 'develop'
   pull_request:
     branches:
-      - '**'
+      - 'develop'
 jobs:
   tests:
     name: Run Tests
@@ -17,7 +16,12 @@ jobs:
         node:
           - 12.x
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
+        if: github.event_name == 'push'
+      - use: actions/checkout@v2
+        if: github.event_name == 'pull_request'
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
       - name: Use Node.js ${{ matrix.node }}
         uses: actions/setup-node@v1
         with:
@@ -39,7 +43,6 @@ jobs:
         run: yarn test --ci --coverage -i
       - name: Send to Code Cov
         uses: codecov/codecov-action@v1
-        if: github.event_name == 'push'
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          yml: './codecov.yml'
+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,11 +17,6 @@ jobs:
           - 12.x
     steps:
       - uses: actions/checkout@v2
-        if: github.event_name == 'push'
-      - uses: actions/checkout@v2
-        if: github.event_name == 'pull_request'
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
       - name: Use Node.js ${{ matrix.node }}
         uses: actions/setup-node@v1
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         if: github.event_name == 'push'
-      - use: actions/checkout@v2
+      - uses: actions/checkout@v2
         if: github.event_name == 'pull_request'
         with:
           ref: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -8,7 +8,7 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - uses: actions/github-script@0.3.0
         name: Create Deployment
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,8 +53,6 @@ jobs:
         run: scripts/release.sh
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Make Empty Commit
-        run: |
       - name: Set Deployment Status Success
         run: yarn deploy:status success
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,13 +8,21 @@ jobs:
       matrix:
         node: [12.x]
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
+      - uses: actions/checkout@v2
+        name: Checkout Flexget
+        with:
+          ref: develop
+          path: flexget
       - name: Setup Git
         run: |
-          git config --local user.email $GIT_EMAIL
-          git config --local user.name $GIT_USERNAME
+          git config user.email $GIT_EMAIL
+          git config user.name $GIT_USERNAME
           git checkout ${GITHUB_REF:11}
           git remote set-url origin https://$GIT_USERNAME:$GITHUB_TOKEN@github.com/$GITHUB_REPOSITORY
+          cd flexget
+          git remote set-url origin https://$GIT_USERNAME:$GITHUB_TOKEN@github.com/Flexget/flexget
+          cd ..
         env:
           GIT_EMAIL: ${{ secrets.GIT_EMAIL }}
           GIT_USERNAME: ${{ secrets.GIT_USERNAME }}
@@ -45,6 +53,8 @@ jobs:
         run: scripts/release.sh
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Make Empty Commit
+        run: |
       - name: Set Deployment Status Success
         run: yarn deploy:status success
         env:

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -26,6 +26,10 @@ if git log --skip 1 origin/master..origin/develop|grep '^commit '; then
   if [ $? -eq 0 ]; then
     yarn release:upload $VERSION
   fi
+  # Add empty commit to main repo
+  cd flexget
+  git commit --allow-empty  -m "[Add] New webui release"
+  git push
 else
   echo "No commits, skipping release"
 fi

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -28,7 +28,7 @@ if git log --skip 1 origin/master..origin/develop|grep '^commit '; then
   fi
   # Add empty commit to main repo
   cd flexget
-  git commit --allow-empty  -m "[Add] New webui release"
+  git commit --allow-empty  -m "[Add] webui version $VERSION"
   git push
 else
   echo "No commits, skipping release"


### PR DESCRIPTION
### Motivation for changes:
Right now the only way for webui updates to be picked up by flexget is if there are other changes in flexget. We should be able to create a  new release of flexget for just webui changes. 

### Detailed changes:
- Makes an empty commit to flexget when a webui release is published. This will make it so the next nightly release of flexget will definitely make a new release