### PR TITLE
fix tvmaze episode identifier

### DIFF
--- a/src/core/entry/lookup/episodes.ts
+++ b/src/core/entry/lookup/episodes.ts
@@ -97,7 +97,7 @@ export interface TVMazeOptions {
 const tvMazeToFields = (episode: TVMazeEpisode): EpisodeFields => ({
   seriesEpisode: episode.number,
   seriesSeason: episode.seasonNumber,
-  seriesId: `S${pad(episode.number)}E${pad(episode.seasonNumber)}`,
+  seriesId: `S${pad(episode.seasonNumber)}E${pad(episode.number)}`,
   [TVMazeFields.Image]: episode.originalImage,
   [TVMazeFields.Description]: episode.summary,
   [TVMazeFields.Url]: episode.url,


### PR DESCRIPTION
### Motivation for changes:
I accidentally reversed season and episode numbers for tv maze lookup...this fixes.

### Addressed issues:
- Fixes #76 


