### PR TITLE
Leverage 'imdb_id" for TMDB movie lookup

### DIFF
--- a/src/core/entry/lookup/movies.ts
+++ b/src/core/entry/lookup/movies.ts
@@ -7,6 +7,7 @@ import { toMovieEntry } from '../utils';
 
 export interface TMDBOptions {
   title?: string;
+  imdbId?: string | number;
   tmdbId?: string | number;
   language?: string;
   year?: number;
@@ -168,6 +169,7 @@ export const useTraktLookup = (options: TraktOptions) => {
 export const useMovieLookup = (movie: MovieEntry) => {
   const { loading: tmdbLoading, entry: tmdbEntry } = useTMDBLookup({
     title: movie.movieName,
+    imdbId: movie[IMDBFields.ID],    
     tmdbId: movie[TMDBFields.ID],
     includePosters: true,
     includeBackdrops: true,

--- a/src/core/entry/lookup/movies.ts
+++ b/src/core/entry/lookup/movies.ts
@@ -7,7 +7,7 @@ import { toMovieEntry } from '../utils';
 
 export interface TMDBOptions {
   title?: string;
-	imdbId?: string | number;
+  imdbId?: string | number;
   tmdbId?: string | number;
   language?: string;
   year?: number;
@@ -169,7 +169,7 @@ export const useTraktLookup = (options: TraktOptions) => {
 export const useMovieLookup = (movie: MovieEntry) => {
   const { loading: tmdbLoading, entry: tmdbEntry } = useTMDBLookup({
     title: movie.movieName,
-		imdbId: movie[IMDBFields.ID],    
+    imdbId: movie[IMDBFields.ID],    
     tmdbId: movie[TMDBFields.ID],
     includePosters: true,
     includeBackdrops: true,

--- a/src/core/entry/lookup/movies.ts
+++ b/src/core/entry/lookup/movies.ts
@@ -169,7 +169,7 @@ export const useTraktLookup = (options: TraktOptions) => {
 export const useMovieLookup = (movie: MovieEntry) => {
   const { loading: tmdbLoading, entry: tmdbEntry } = useTMDBLookup({
     title: movie.movieName,
-    imdbId: movie[IMDBFields.ID],    
+    imdbId: movie[IMDBFields.ID],
     tmdbId: movie[TMDBFields.ID],
     includePosters: true,
     includeBackdrops: true,

--- a/src/core/entry/lookup/movies.ts
+++ b/src/core/entry/lookup/movies.ts
@@ -7,7 +7,7 @@ import { toMovieEntry } from '../utils';
 
 export interface TMDBOptions {
   title?: string;
-  imdbId?: string | number;
+	imdbId?: string | number;
   tmdbId?: string | number;
   language?: string;
   year?: number;
@@ -169,7 +169,7 @@ export const useTraktLookup = (options: TraktOptions) => {
 export const useMovieLookup = (movie: MovieEntry) => {
   const { loading: tmdbLoading, entry: tmdbEntry } = useTMDBLookup({
     title: movie.movieName,
-    imdbId: movie[IMDBFields.ID],    
+		imdbId: movie[IMDBFields.ID],    
     tmdbId: movie[TMDBFields.ID],
     includePosters: true,
     includeBackdrops: true,


### PR DESCRIPTION


### Motivation for changes:

Wrong movie details is displayed in "Movie list" view, for entry with `imdb_id` but no `tmdb_id`.

WEBui only leverage  `tmdb_id` and `movie.title` for API TMDB lookup. Even if `imdb_id' is available for the entry.

Flexget TMDB API can leverage `imdb_id` to research a movie when `tmdb_id` is not provided. Results are more accurate than searching by title. 
See recent [commit](https://github.com/Flexget/Flexget/commit/b990741e6f6b2baa0164c3e3c5bd90c2b8458628) 

This change add the `imdb_id` field to the API TMDB request in `useMovieLookup` used when displaying "Movie Lists" tab.

### Detailed changes:
- Add `imdb_id` along `tmdb_id` in request to TMDB API from `useMovieLookup`

### Addressed issues:
- WEBui only leverage  `tmdb_id` and `movie.title` for API TMDB lookup. Even if `imdb_id' is available for the entry.

### Implemented feature requests:
- N.A

#### To Do:

- [ ] N.A

