### PR TITLE
Update webpack.config.js

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -106,6 +106,9 @@ const config = {
       {
         test: /\.(ttf|eot|svg)(\?v=[0-9]\.[0-9]\.[0-9])?$/,
         loader: 'file-loader',
+        options: {
+          esModule: false,
+        },
       },
       {
         test: /\.(gif|png|jpg|jpeg)(\?[a-z0-9]+)?$/,


### PR DESCRIPTION
set 'file-loader' esModule as false to deal with the picture dir missing problem

### Motivation for changes:
shortcut href = [object Module]

### Detailed changes:
- file-loader add options: {  esModule: false, }

### Addressed issues:
- Fixes # .

### Implemented feature requests:
- Feathub #[XX](https://feathub.com/Flexget/Flexget/+XX).

#### To Do:

- [ ] Stuff..

