### PR TITLE
Fix [object module] showing up instead of the favicon

### DIFF
--- a/src/index.ejs
+++ b/src/index.ejs
@@ -5,7 +5,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
   <meta http-equiv="x-ua-compatible" content="ie=edge">
-  <link rel="shortcut icon" href="<%= require('./favicon.png') %>">
+  <link rel="shortcut icon" href="<%= require('./favicon.png').default %>">
   <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
   <title><%= htmlWebpackPlugin.options.title %></title>
 </head>


### PR DESCRIPTION
### Addressed issues:
- Fixes #109 

