### PR TITLE
fix: no longer shows an auth error when you first login

### DIFF
--- a/src/core/layout/SideNav/hooks.tsx
+++ b/src/core/layout/SideNav/hooks.tsx
@@ -1,8 +1,7 @@
 import { useEffect, useState } from 'react';
 import { useFlexgetAPI } from 'core/api';
-import { createContainer } from 'unstated-next';
+import { createContainer, useContainer } from 'unstated-next';
 import { AuthContainer } from 'core/auth/hooks';
-import { useGlobalStatus } from 'core/status/hooks';
 
 interface VersionResponse {
   apiVersion: string;
@@ -11,10 +10,9 @@ interface VersionResponse {
 }
 
 export const VersionContainer = createContainer(() => {
-  const [loggedIn] = AuthContainer.useContainer();
+  const [loggedIn] = useContainer(AuthContainer);
   const [version, setVersion] = useState<VersionResponse>();
-  const [{ loading, error }, getVersion] = useFlexgetAPI<VersionResponse>('/server/version');
-  useGlobalStatus(loading, error);
+  const [{ loading }, getVersion] = useFlexgetAPI<VersionResponse>('/server/version');
 
   useEffect(() => {
     const fn = async () => {


### PR DESCRIPTION
### Motivation for changes:
An auth error showed up in the toast when you first logged in . This was do to initially attempting to get the version in the sidebar which is how we check if you are logged in. 

### Detailed changes:
- Don't log errors to the global status from the sidenav version component

### Addressed issues:
- Fixes #120 


