### PR TITLE
fix: allow execution of newly created task

### DIFF
--- a/src/plugins/config/Config.spec.tsx
+++ b/src/plugins/config/Config.spec.tsx
@@ -4,14 +4,15 @@ import { cleanup, fireEvent, wait } from '@testing-library/react';
 import { renderWithWrapper } from 'utils/tests';
 import AppBar from 'core/layout/AppBar';
 import { Method } from 'utils/fetch';
+import { TaskContainer } from 'plugins/tasks/hooks';
 import Config from './Config';
 
 const TestConfig: FC = () => {
   return (
-    <>
+    <TaskContainer.Provider>
       <AppBar toggleSidebar={jest.fn()} />
       <Config />
-    </>
+    </TaskContainer.Provider>
   );
 };
 const config = `
@@ -29,6 +30,7 @@ describe('plugins/config/Config', () => {
         message: 'Success',
       })
       .get('/api/variables', {})
+      .get('/api/tasks', [])
       .get('/api/schema', {
         schemas: [],
       })
@@ -68,9 +70,8 @@ describe('plugins/config/Config', () => {
       fireEvent.click(saveButton);
     }
 
-    await wait(() =>
-      expect(fetchMock.called('/api/server/raw_config', { method: Method.Post })).toBeTrue(),
-    );
+    await wait(() => expect(fetchMock.called('/api/tasks')).toBeTrue());
+    expect(fetchMock.called('/api/server/raw_config', { method: Method.Post })).toBeTrue();
   });
 
   it('clicking load variables should switch to variables mode', async () => {

--- a/src/plugins/config/hooks.ts
+++ b/src/plugins/config/hooks.ts
@@ -4,6 +4,8 @@ import { useFlexgetAPI } from 'core/api';
 import { Method } from 'utils/fetch';
 import { useGlobalInfo } from 'core/status/hooks';
 import { atobUTF16, btoaUTF16 } from 'utils/encoding';
+import { TaskContainer } from 'plugins/tasks/hooks';
+import { useContainer } from 'unstated-next';
 import { Schema } from './types';
 
 interface RawConfigResp {
@@ -18,6 +20,7 @@ export const useGetConfig = () => {
   const [get, getRequest] = useFlexgetAPI<RawConfigResp>('/server/raw_config');
   const [post, postRequest] = useFlexgetAPI<MessageResponse>('/server/raw_config', Method.Post);
   const [config, setConfig] = useState('');
+  const { refresh } = useContainer(TaskContainer);
   const pushInfo = useGlobalInfo();
 
   useEffect(() => {
@@ -37,10 +40,11 @@ export const useGetConfig = () => {
       if (resp.ok) {
         setConfig(v);
         pushInfo(resp.data.message);
+        refresh();
       }
       return resp;
     },
-    [postRequest, pushInfo],
+    [postRequest, pushInfo, refresh],
   );
 
   return [{ config, state: { get, post } }, saveConfig] as const;

--- a/src/plugins/tasks/Latest.tsx
+++ b/src/plugins/tasks/Latest.tsx
@@ -4,9 +4,10 @@ import { useHistory, useRouteMatch } from 'react-router';
 import { CheckCircle, Error } from '@material-ui/icons';
 import { useInjectPageTitle } from 'core/layout/AppBar/hooks';
 import { Direction } from 'utils/query';
+import { useContainer } from 'unstated-next';
 import { SortByStatus, TaskStatusOptions } from './types';
 import TaskTable from './TaskTable';
-import { useGetTaskStatuses } from './hooks';
+import { useGetTaskStatuses, TaskContainer } from './hooks';
 import Execute from './Execute';
 
 const headers = [
@@ -67,6 +68,7 @@ const Latest: FC = () => {
   });
 
   const { tasks, total } = useGetTaskStatuses(options);
+  const { tasks: configTasks } = useContainer(TaskContainer);
   const rows = useMemo(
     () =>
       tasks.map(
@@ -116,7 +118,7 @@ const Latest: FC = () => {
       <Formik initialValues={options} onSubmit={setOptions}>
         <TaskTable total={total} rows={rows} headers={headers} />
       </Formik>
-      <Execute tasks={tasks} />
+      <Execute tasks={configTasks} />
     </>
   );
 };

--- a/src/plugins/tasks/Tasks.spec.tsx
+++ b/src/plugins/tasks/Tasks.spec.tsx
@@ -5,6 +5,7 @@ import fetchMock from 'fetch-mock';
 import { renderWithWrapper } from 'utils/tests';
 import AppBar from 'core/layout/AppBar';
 import Tasks from './Tasks';
+import { TaskContainer } from './hooks';
 
 interface Props {
   path: string;
@@ -16,14 +17,14 @@ const TestTasks: FC<Props> = ({ path }) => {
     push(path);
   }, [path, push]);
   return (
-    <>
+    <TaskContainer.Provider>
       <AppBar toggleSidebar={jest.fn()} />
       <Switch>
         <Route path="/tasks">
           <Tasks />
         </Route>
       </Switch>
-    </>
+    </TaskContainer.Provider>
   );
 };
 
@@ -33,6 +34,7 @@ describe('plugins/tasks', () => {
       .get('glob:/api/tasks/status?*', [])
       .get('glob:/api/tasks/status/1', {})
       .get('glob:/api/tasks/status/1/executions?*', [])
+      .get('/api/tasks', [])
       .catch();
   });
 

--- a/src/plugins/tasks/hooks.ts
+++ b/src/plugins/tasks/hooks.ts
@@ -28,17 +28,18 @@ export const TaskContainer = createContainer(() => {
   const [tasks, setTasks] = useState<Task[]>([]);
   const [state, request] = useFlexgetAPI<Task[]>('/tasks');
 
-  useEffect(() => {
-    const fn = async () => {
-      const resp = await request();
-      if (resp.ok) {
-        setTasks(resp.data);
-      }
-    };
-    fn();
+  const refresh = useCallback(async () => {
+    const resp = await request();
+    if (resp.ok) {
+      setTasks(resp.data);
+    }
   }, [request]);
 
-  return { ...state, tasks };
+  useEffect(() => {
+    refresh();
+  }, [refresh]);
+
+  return { ...state, tasks, refresh };
 });
 
 export const useExecuteTask = () => {
@@ -58,6 +59,8 @@ export const useGetTaskStatuses = (options: TaskStatusOptions) => {
   const [tasks, setTasks] = useState<TaskState>({ tasks: [], total: 0 });
   const query = stringify(snakeCase({ ...options, page: (options.page ?? 0) + 1 }));
   const [state, request] = useFlexgetAPI<TaskStatus[]>(`/tasks/status?${query}`);
+  // const { tasks: configTasks } = useContainer(TaskContainer);
+  // const { sortBy } = options;
 
   useEffect(() => {
     const fn = async () => {
@@ -68,6 +71,20 @@ export const useGetTaskStatuses = (options: TaskStatusOptions) => {
     };
     fn();
   }, [request]);
+
+  // useMemo(() => {
+  // const map = {};
+  // const nt: Task[] = [...tasks];
+
+  // tasks.tasks.forEach(t => {
+  // map[t.id] = t;
+  // });
+  // configTasks.forEach(t => {
+  // if (!map[t.id]) {
+  // nt.push(t);
+  // }
+  // });
+  // });
 
   return { ...state, ...tasks };
 };

--- a/src/plugins/tasks/types.ts
+++ b/src/plugins/tasks/types.ts
@@ -4,6 +4,8 @@ import { RawEntry } from 'core/entry/types';
 export interface Task {
   id: number;
   name: string;
+  lastExecutionTime?: string;
+  lastExecution?: Partial<Execution>;
 }
 
 export interface Inject {
@@ -62,7 +64,7 @@ export const enum SortByStatus {
   AbortReason = 'abort_reason',
 }
 
-export interface TaskStatusOptions extends Partial<DefaultOptions {
+export interface TaskStatusOptions extends Partial<DefaultOptions> {
   sortBy: SortByStatus;
 }
 

--- a/src/plugins/tasks/types.ts
+++ b/src/plugins/tasks/types.ts
@@ -62,7 +62,7 @@ export const enum SortByStatus {
   AbortReason = 'abort_reason',
 }
 
-export interface TaskStatusOptions extends Partial<DefaultOptions> {
+export interface TaskStatusOptions extends Partial<DefaultOptions {
   sortBy: SortByStatus;
 }
 


### PR DESCRIPTION
### Motivation for changes:
From the tasks execute page, you can't execute a task unless it has been previously executed

### Detailed changes:
- Re pull the global task list everytime config.yml is saved
- Use the global task list in the execute dialog instead of latest executions. 

### Addressed issues:
- Fixes #114


