### PR TITLE
feat: use auth/verify instead version to determine whether you are logged in

### DIFF
--- a/src/Root.tsx
+++ b/src/Root.tsx
@@ -21,7 +21,6 @@ import { TaskContainer } from 'plugins/tasks/hooks';
 import { StatusContainer } from 'core/status/hooks';
 import { PluginContainer } from 'core/plugins/hooks';
 import ThemeProvider from 'core/theme/ThemeProvider';
-import { VersionContainer } from 'core/layout/SideNav/hooks';
 import { uriParser } from 'utils';
 import LoadingSpinner from 'common/LoadingSpinner';
 
@@ -65,31 +64,29 @@ const Root: FC = () => (
     <StylesProvider injectFirst>
       <StatusContainer.Provider>
         <AuthContainer.Provider>
-          <VersionContainer.Provider>
-            <BrowserRouter basename={basename}>
-              <Suspense fallback={LoadingSpinner}>
-                <Switch>
-                  <Route path="/login" exact component={Login} />
-                  <Route
-                    render={() => (
-                      <PluginContainer.Provider>
-                        <TaskContainer.Provider>
-                          <Layout>
-                            <Suspense fallback={LoadingSpinner}>
-                              <Switch>
-                                <PrivateRoute path="/" exact component={Home} />
-                                <Route component={Routes} />
-                              </Switch>
-                            </Suspense>
-                          </Layout>
-                        </TaskContainer.Provider>
-                      </PluginContainer.Provider>
-                    )}
-                  />
-                </Switch>
-              </Suspense>
-            </BrowserRouter>
-          </VersionContainer.Provider>
+          <BrowserRouter basename={basename}>
+            <Suspense fallback={LoadingSpinner}>
+              <Switch>
+                <Route path="/login" exact component={Login} />
+                <Route
+                  render={() => (
+                    <PluginContainer.Provider>
+                      <TaskContainer.Provider>
+                        <Layout>
+                          <Suspense fallback={LoadingSpinner}>
+                            <Switch>
+                              <PrivateRoute path="/" exact component={Home} />
+                              <Route component={Routes} />
+                            </Switch>
+                          </Suspense>
+                        </Layout>
+                      </TaskContainer.Provider>
+                    </PluginContainer.Provider>
+                  )}
+                />
+              </Switch>
+            </Suspense>
+          </BrowserRouter>
         </AuthContainer.Provider>
       </StatusContainer.Provider>
     </StylesProvider>

--- a/src/core/auth/Login.tsx
+++ b/src/core/auth/Login.tsx
@@ -14,19 +14,19 @@ const LoginPage: FC<Props> = ({ location }) => {
   const { from } = location?.state ?? { from: { pathname: '/' } };
   const [loggedIn, setLoggedIn] = useContainer(AuthContainer);
 
-  const [versionState, getVersion] = useFlexgetAPI('/server/version');
+  const [loginState, checkLogin] = useFlexgetAPI('/auth/verify');
 
   useEffect(() => {
     const fn = async () => {
-      const resp = await getVersion();
+      const resp = await checkLogin();
       if (resp.ok) {
         setLoggedIn(true);
       }
     };
     fn();
-  }, [getVersion, setLoggedIn]);
+  }, [checkLogin, setLoggedIn]);
 
-  if (versionState.loading) {
+  if (loginState.loading) {
     return <SplashScreen />;
   }
 

--- a/src/core/auth/Login.tsx
+++ b/src/core/auth/Login.tsx
@@ -14,7 +14,7 @@ const LoginPage: FC<Props> = ({ location }) => {
   const { from } = location?.state ?? { from: { pathname: '/' } };
   const [loggedIn, setLoggedIn] = useContainer(AuthContainer);
 
-  const [loginState, checkLogin] = useFlexgetAPI('/auth/verify');
+  const [loginState, checkLogin] = useFlexgetAPI('/user/token');
 
   useEffect(() => {
     const fn = async () => {

--- a/src/core/layout/Layout.spec.tsx
+++ b/src/core/layout/Layout.spec.tsx
@@ -3,15 +3,12 @@ import fetchMock from 'fetch-mock';
 import { act, create, ReactTestRenderer } from 'react-test-renderer';
 import { BaseProviders } from 'utils/tests';
 import Layout from './Layout';
-import { VersionContainer } from './SideNav/hooks';
 
 const renderLayout = () => (
   <BaseProviders>
-    <VersionContainer.Provider>
-      <Layout>
-        <div />
-      </Layout>
-    </VersionContainer.Provider>
+    <Layout>
+      <div />
+    </Layout>
   </BaseProviders>
 );
 describe('common/layout', () => {

--- a/src/core/layout/SideNav/Version.spec.tsx
+++ b/src/core/layout/SideNav/Version.spec.tsx
@@ -3,7 +3,6 @@ import fetchMock from 'fetch-mock';
 import { cleanup } from '@testing-library/react';
 import { renderWithWrapper } from 'utils/tests';
 import Version from './Version';
-import { VersionContainer } from './hooks';
 
 describe('core/layout/Version', () => {
   afterEach(() => {
@@ -11,11 +10,7 @@ describe('core/layout/Version', () => {
     fetchMock.reset();
   });
 
-  const component = (
-    <VersionContainer.Provider>
-      <Version />
-    </VersionContainer.Provider>
-  );
+  const component = <Version />;
 
   it('does not show icon with latest version', async () => {
     fetchMock.get('/api/server/version', {

--- a/src/core/layout/SideNav/Version.tsx
+++ b/src/core/layout/SideNav/Version.tsx
@@ -1,11 +1,10 @@
 import React, { FC } from 'react';
-import { useContainer } from 'unstated-next';
 import { gt } from 'semver';
 import { css } from '@emotion/core';
 import { IconButton, Theme } from '@material-ui/core';
 import HelpOutlineIcon from '@material-ui/icons/HelpOutline';
 import Typography from '@material-ui/core/Typography';
-import { VersionContainer } from './hooks';
+import { useVersion } from './hooks';
 
 interface Props {
   className?: string;
@@ -18,7 +17,7 @@ const wrapper = (theme: Theme) => css`
 `;
 
 const Version: FC<Props> = ({ className }) => {
-  const { loading, version } = useContainer(VersionContainer);
+  const { loading, version } = useVersion();
 
   if (loading || !version) {
     // showProgress

--- a/src/core/layout/SideNav/hooks.tsx
+++ b/src/core/layout/SideNav/hooks.tsx
@@ -1,7 +1,5 @@
 import { useEffect, useState } from 'react';
 import { useFlexgetAPI } from 'core/api';
-import { createContainer, useContainer } from 'unstated-next';
-import { AuthContainer } from 'core/auth/hooks';
 
 interface VersionResponse {
   apiVersion: string;
@@ -9,22 +7,19 @@ interface VersionResponse {
   latestVersion: string;
 }
 
-export const VersionContainer = createContainer(() => {
-  const [loggedIn] = useContainer(AuthContainer);
+export const useVersion = () => {
   const [version, setVersion] = useState<VersionResponse>();
   const [{ loading }, getVersion] = useFlexgetAPI<VersionResponse>('/server/version');
 
   useEffect(() => {
     const fn = async () => {
-      if (!loggedIn) {
-        const resp = await getVersion();
-        if (resp.ok) {
-          setVersion(resp.data);
-        }
+      const resp = await getVersion();
+      if (resp.ok) {
+        setVersion(resp.data);
       }
     };
     fn();
-  }, [getVersion, loggedIn]);
+  }, [getVersion]);
 
   return { loading, version };
-});
+};


### PR DESCRIPTION
### Motivation for changes:
* Currently we use the version endpoint to determine whether or not you are logged in on webui. This initial call will block rendering of everything until resolved. The version endpoint has to call out to PyPy which is not great in places that it takes a while to resolve. So instead i made a dedicated endpoint to use for this purpose that doesn't really do anything at all other than check auth. This PR changes webui to use the new endpoint

### Addressed issues:
- Flexget/Flexget#2725 

Dependent on Flexget/Flexget#2731
