### PR TITLE
fix: lock to minor version for typescript

### DIFF
--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
     "style-loader": "^1.1.3",
     "ts-jest": "^25.1.0",
     "ts-loader": "^6.0.4",
-    "typescript": "^3.7.2",
+    "typescript": "~3.7.2",
     "url-loader": "^3.0.0",
     "webpack": "^4.36.1",
     "webpack-bundle-analyzer": "^3.3.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10116,10 +10116,10 @@ typeface-roboto@0.0.75:
   resolved "https://registry.yarnpkg.com/typeface-roboto/-/typeface-roboto-0.0.75.tgz#98d5ba35ec234bbc7172374c8297277099cc712b"
   integrity sha512-VrR/IiH00Z1tFP4vDGfwZ1esNqTiDMchBEXYY9kilT6wRGgFoCAlgkEUMHb1E3mB0FsfZhv756IF0+R+SFPfdg==
 
-typescript@^3.7.2:
-  version "3.9.7"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.7.tgz#98d600a5ebdc38f40cb277522f12dc800e9e25fa"
-  integrity sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==
+typescript@~3.7.2:
+  version "3.7.5"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.7.5.tgz#0692e21f65fd4108b9330238aac11dd2e177a1ae"
+  integrity sha512-/P5lkRXkWHNAbcJIiHPfRoKqyd7bsyCma1hZNUGfn20qm64T6ZBlrzprymeu918H+mB/0rIg2gGK/BXkhhYgBw==
 
 uglify-js@3.4.x:
   version "3.4.10"


### PR DESCRIPTION
### Motivation for changes:
* There are some changes in typescript 3.8 that cause our current types declarations to no longer work properly so locking 3.7 minor until it can be investigated. 

