### PR TITLE
Fix useMovieAPI type definitions

### DIFF
--- a/src/plugins/lists/movies/hooks.tsx
+++ b/src/plugins/lists/movies/hooks.tsx
@@ -24,7 +24,7 @@ function useMovieAPI<T extends Movie>(url: string, method?: Method): [RequestSta
 function useMovieAPI<T extends Movie[]>(
   url: string,
   method?: Method,
-): [RequestState, APIRequest<T[]>];
+): [RequestState, APIRequest<T>];
 function useMovieAPI(url: string, method?: Method) {
   const [state, makeRequest] = useFlexgetAPI<Movie | Movie[]>(url, method);
 


### PR DESCRIPTION
### Motivation for changes:
Building fails with following error:
```
ERROR in .../webui/src/plugins/lists/movies/hooks.tsx
ERROR in .../webui/src/plugins/lists/movies/hooks.tsx(48,57):
TS2345: Argument of type '() => { sortByOptions: { value: SortBy; label: string; }[]; addEntryProps: ({ label: string; name: string; type?: undefined; } | { label: string; name: string; type: string; })[]; api: { list: { useGet: () => [RequestState, APIRequest<...>]; useAdd: () => [...]; useRemove: (listId?: number | undefined) => [...]; }; ...' is not assignabl
e to parameter of type '(initialState?: void | undefined) => ListState<Entry>'.
```

### Detailed changes:
Fix function signature of `useMovieAPI`

### Addressed issues:
-

### Implemented feature requests:
-

#### To Do:
-

