### PR TITLE
Add cleanFlexgetVersion to process semver strings

### DIFF
--- a/src/core/layout/SideNav/Version.spec.tsx
+++ b/src/core/layout/SideNav/Version.spec.tsx
@@ -55,4 +55,15 @@ describe('core/layout/Version', () => {
     expect(await findByText('Flexget: 2.10.11')).toBeInTheDocument();
     expect(queryByLabelText('flexget update available')).toBeInTheDocument();
   });
+
+  it('handles incomplete semver versions', async () => {
+    fetchMock.get('/api/server/version', {
+      apiVersion: '1.1.2',
+      flexgetVersion: '2.10',
+      latestVersion: '2.11',
+    });
+    const { findByText, queryByLabelText } = renderWithWrapper(component);
+    expect(await findByText('Flexget: 2.10')).toBeInTheDocument();
+    expect(queryByLabelText('flexget update available')).toBeInTheDocument();
+  });
 });

--- a/src/core/layout/SideNav/Version.tsx
+++ b/src/core/layout/SideNav/Version.tsx
@@ -4,6 +4,7 @@ import { css } from '@emotion/core';
 import { IconButton, Theme } from '@material-ui/core';
 import HelpOutlineIcon from '@material-ui/icons/HelpOutline';
 import Typography from '@material-ui/core/Typography';
+import { cleanFlexgetVersion } from 'utils/version';
 import { useVersion } from './hooks';
 
 interface Props {
@@ -26,14 +27,15 @@ const Version: FC<Props> = ({ className }) => {
 
   const { flexgetVersion, apiVersion, latestVersion } = version;
 
-  const normalizedVersion = flexgetVersion.replace('.dev', '-dev.0');
+  const normalizedVersion = cleanFlexgetVersion(flexgetVersion);
+  const normalizedLatest = cleanFlexgetVersion(latestVersion);
 
   return (
     <div css={wrapper} className={className}>
       <Typography>Version Info</Typography>
       <Typography>
         {`Flexget: ${flexgetVersion} `}
-        {gt(latestVersion, normalizedVersion) && (
+        {gt(normalizedLatest, normalizedVersion) && (
           <IconButton
             href="https://flexget.com/ChangeLog"
             color="inherit"

--- a/src/utils/tests/version.spec.ts
+++ b/src/utils/tests/version.spec.ts
@@ -1,0 +1,57 @@
+import { cleanFlexgetVersion } from 'utils/version';
+
+describe('utils/version', () => {
+  it('parses valid semver', async () => {
+    let version = '1.2.3';
+    let cleaned = cleanFlexgetVersion(version);
+    expect(cleaned).toEqual('1.2.3');
+
+    version = '2.1.0';
+    cleaned = cleanFlexgetVersion(version);
+    expect(cleaned).toEqual('2.1.0');
+
+    version = '1.2.3-dev';
+    cleaned = cleanFlexgetVersion(version);
+    expect(cleaned).toEqual('1.2.3-dev.0');
+
+    version = '1.2.3-dev.1';
+    cleaned = cleanFlexgetVersion(version);
+    expect(cleaned).toEqual('1.2.3-dev.1');
+  });
+
+  it('parses incomplete semver', async () => {
+    let version = '1.1';
+    let cleaned = cleanFlexgetVersion(version);
+    expect(cleaned).toEqual('1.1.0');
+
+    version = '1';
+    cleaned = cleanFlexgetVersion(version);
+    expect(cleaned).toEqual('1.0.0');
+  });
+
+  it('parses .dev prerelease tags', async () => {
+    let version = '1.2.3.dev';
+    let cleaned = cleanFlexgetVersion(version);
+    expect(cleaned).toEqual('1.2.3-dev.0');
+
+    version = '1.2.3.dev.1';
+    cleaned = cleanFlexgetVersion(version);
+    expect(cleaned).toEqual('1.2.3-dev.1');
+
+    version = '1.2.dev';
+    cleaned = cleanFlexgetVersion(version);
+    expect(cleaned).toEqual('1.2.0-dev.0');
+
+    version = '1.2.dev.1';
+    cleaned = cleanFlexgetVersion(version);
+    expect(cleaned).toEqual('1.2.0-dev.1');
+
+    version = '1.dev';
+    cleaned = cleanFlexgetVersion(version);
+    expect(cleaned).toEqual('1.0.0-dev.0');
+
+    version = '1.dev.1';
+    cleaned = cleanFlexgetVersion(version);
+    expect(cleaned).toEqual('1.0.0-dev.1');
+  });
+});

--- a/src/utils/version.ts
+++ b/src/utils/version.ts
@@ -1,0 +1,13 @@
+import { coerce } from 'semver';
+
+export const cleanFlexgetVersion = (version: string) => {
+  const coercedVersion = coerce(version, { includePrerelease: true });
+  if (!coercedVersion) {
+    return '';
+  }
+
+  const regexPrerelease = /(?:\.|-)dev(?:(\.\d+))?/;
+  const preMatch = version.match(regexPrerelease);
+  const preString = preMatch ? `-dev${preMatch[1] || '.0'}` : '';
+  return `${coercedVersion?.format()}${preString}`;
+};


### PR DESCRIPTION
### Motivation for changes:
Fix #182 and try to prevent it from happening again without adding complexity to the server repo.

### Detailed changes:
Given the complexity flexget currently has in their server versioning, I added a utility that attempts to parse the semver version and clean it up according to the flexget logic. I added tests to help demonstrate some of the edge cases.
- Handle incomplete semver `3.9` to `3.9.0`
- Handle existing logic `1.2.3.dev` to `1.2.3-dev.0`
- Handle other minor use cases. 

Originally, I was going to use the `coerce` function built into `semver` to handle the `3.9` to `3.9.0` but that removes prerelease tags and they appear to be useful according to tests.

### Addressed issues:
- Fixes #182 


