### PR TITLE
fix: word wrap titles in entry cards

### DIFF
--- a/src/plugins/lists/base/EntryList/EntryCard.tsx
+++ b/src/plugins/lists/base/EntryList/EntryCard.tsx
@@ -31,6 +31,7 @@ const actionArea = css`
 const entryCard = css`
   flex: 1;
   width: 100%;
+  overflow-wrap: break-word;
 `;
 
 const cardActions = (theme: Theme) => css`


### PR DESCRIPTION
### Motivation for changes:

Long unbreakable titles on entry cards (pending list in my case) are not visible as they overflow the card and just get cut to the card's size. This simple css forces a line break on those titles and doesn't seem to alter the layout in a bad way.


