### PR TITLE
Fix series images not loading through Reverse Proxy over HTTPS

### DIFF
--- a/src/utils/image.ts
+++ b/src/utils/image.ts
@@ -1,4 +1,4 @@
 import { uriParser } from 'utils';
 
 export const getCachedUrl = (url: string) =>
-  `${uriParser(document.baseURI).pathname}api/cached?url=${url}`;
+  `${uriParser(document.baseURI).pathname}api/cached?url=${encodeURIComponent(url)}`;


### PR DESCRIPTION

### Motivation for changes:

I run Flexget behind an Nginx Proxy Manager reverse proxy, that provides SSL termination.

When I open Flexget Webui directly on the local network via ip-address/http, the thumbnails on the Series page load without issue.

When I open Flexget Webui via the DNS name (running through the reverse proxy), the thumbnails *do not* load.

### Detailed changes:

encodeURIComponent the image URL passed to the /api/cached proxy endpoint. 

Without encoding, the raw '://' and path separators in the image URL were interpreted inconsistently by HTTPS servers and reverse proxies, causing the cached request to fail or be mangled.
 
### Addressed issues:

- I haven't raised an issue for this, as it was easier to just fix it once I confirmed the issue

### Implemented feature requests:

- NA

#### To Do:

- NA